### PR TITLE
Planning Docs for Razen V3: Hook Primitives, Reactive CLI, and Declarative Validation

### DIFF
--- a/planning/README.md
+++ b/planning/README.md
@@ -1,11 +1,11 @@
-# 🔍 Phase 1: Hook Primitives Planning (Aug 22 – Sep 20)
+# Phase 1: Hook Primitives Planning (Aug 22 – Sep 20)
 
-## 🎯 Objective
+## Objective
 Design and formalize **hook-based constructs** as native language primitives in Razen V3. These should support reactive, declarative, and modular logic across CLI, scripting, and validation contexts.
 
----
+***
 
-## 📦 Core Hook Constructs
+## Core Hook Constructs
 
 | Hook         | Purpose                          | Example Usage                                                  |
 |--------------|----------------------------------|----------------------------------------------------------------|
@@ -13,52 +13,60 @@ Design and formalize **hook-based constructs** as native language primitives in 
 | `useEvent`     | React to external/internal triggers | `hook useEvent { trigger: fileChange, action: reloadConfig }`  |
 | `useTrace` / `useProfile` | Runtime introspection | `hook useTrace { scope: "auth", level: "debug" }`              |
 
----
+***
 
-## 🧠 Design Goals
+## Design Goals
 
-- **Declarative Syntax**: Hooks should be readable and composable.
-- **Token Alignment**: Must conform to Razen’s token and annotation rules.
-- **Modular Behavior**: Hooks should encapsulate state, lifecycle, and error logic.
-- **Cross-Context Usability**: Hooks should work in CLI, scripting, and agentic flows.
+- **Declarative Syntax**: Hooks should be readable and composable without excessive boilerplate.
+- **Token Alignment**: Must work seamlessly with Razen's existing token system and type annotations.
+- **Modular Behavior**: Each hook should encapsulate its own state, lifecycle, and error handling logic.
+- **Cross-Context Usability**: Hooks need to function consistently across CLI tools, scripts, and automated workflows.
 
----
+***
 
-## 🧪 Tasks for This Phase
+## Tasks for This Phase
 
-1. **Syntax Refinement**
-   - Define grammar for `hook` blocks
-   - Align with Razen’s token system (e.g. annotations, delimiters)
+### 1. Syntax Refinement
+   - Define clear grammar rules for `hook` blocks
+   - Ensure compatibility with Razen's type system (`var name: type` syntax)
+   - Test edge cases with nested hooks and complex expressions
 
-2. **Example Library**
-   - Create `.razen` files for each hook type
-   - Include tree-based reactive logic and CLI workflows
+### 2. Example Library
+   - Create practical `.rzn` files demonstrating each hook type
+   - Include tree-based reactive examples and CLI workflow patterns
+   - Focus on real-world use cases that developers would actually encounter
 
-3. **Conflict Resolution**
-   - Identify where React-style patterns break Razen rules
-   - Propose alternatives or adaptations
+### 3. Conflict Resolution
+   - Identify where React-style patterns might conflict with Razen's philosophy
+   - Propose Razen-native alternatives that maintain simplicity
+   - Document trade-offs between familiarity and language consistency
 
-4. **Documentation**
-   - Draft this spec file (`V3_Hook_Primitives.md`)
-   - Create a shared Notion or markdown doc for collaborative planning
+### 4. Documentation
+   - Complete this specification document
+   - Create clear examples with explanations
+   - Document integration points with existing Razen features
 
-5. **Feedback Loop**
-   - Share examples with Razen creator
-   - Iterate based on syntax feedback and token constraints
+### 5. Feedback Integration
+   - Share working examples for syntax validation
+   - Iterate based on parsing complexity and performance considerations
+   - Refine based on real implementation constraints
 
----
+***
 
-## 📌 Deliverables by Sep 20
+## Deliverables by Sep 20
 
-- ✅ Planning folder in GitHub fork
-- ✅ Hook spec document (`V3_Hook_Primitives.md`)
-- ✅ At least 3 working examples (`tree_hooks.razen`, `validator_hooks.razen`, `cli_agent.razen`)
-- ✅ Syntax notes and open questions
-- ✅ Roadmap for Phase 2 implementation
+- Planning documentation in project repository
+- Complete hook specification document
+- At least 3 working examples: tree management, validation workflows, and CLI automation
+- Syntax compatibility notes and unresolved questions
+- Clear roadmap for Phase 2 implementation with priority ordering
 
----
+***
 
-## ✨ Vision Statement
+## Vision Statement
 
-> **Newly updated Razen aims to make hooks a language-native primitive—not just for UI, but for modular state, validation, and enhanced CLI and scripting. Declarative, reactive, and introspective by design. This isn’t just an update—it’s a tectonic shift. The new Razen unlocks a new phase in programming, powered by constructs that challenge convention and redefine clarity. The new wave starts here.**
+Razen V3 introduces hooks as first-class language primitives, extending reactive programming beyond user interfaces into system scripting, data validation, and CLI automation. This approach makes state management and side effects declarative by default, reducing boilerplate while maintaining Razen's commitment to simplicity and performance.
 
+The goal is not to copy React, but to adapt its proven concepts for general-purpose programming. Where React hooks manage component lifecycle, Razen hooks will manage application lifecycle, file system events, network requests, and data transformations.
+
+This represents a fundamental shift toward declarative system programming - where developers describe what should happen rather than imperatively managing how it happens.


### PR DESCRIPTION
This PR introduces Phase 1 planning for new Razen, focused on integrating hook-based reactive constructs as native language primitives.

Includes:
- Vision statement for new updated Razen as a declarative, introspective, agentic language

Looking forward to feedback and alignment on syntax before implementation begins post Sep 20.
